### PR TITLE
Fix podAnnotations and resources indent

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 5.0.2
+version: 5.0.3
 appVersion: 2.7.2
 home: https://centrifugal.github.io/centrifugo/
 icon: https://centrifugal.github.io/centrifugo/images/favicon.png

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
-        {{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
         {{- include "centrifugo.selectorLabels" . | nindent 8 }}
@@ -145,7 +145,7 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 10
           resources:
-            {{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Providing `podAnnotations`, `resources` currently renders invalid yaml:

```
$ helm template centrifugo centrifugal/centrifugo --version 5.0.2 --values values.yaml --debug
# ...
  template:
    metadata:
      annotations:
        checksum/config: 3022f319b67a2d3a6775716bc314fccb6e53e284877e215322dd0328caaee1b4
        checksum/secret: 706dbf1028a526b9571e798c88347c2ee6c65ef6e0f8304431dff59aef29b54c
                prometheus.io/port: "9000"
        prometheus.io/scrape: "true"
# ...
          resources:
                        requests:
              cpu: 50m
              memory: 100M
# ...
```

This change should fix the problem.
