### PR TITLE
Quote values of environment variables

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 6.0.1
+version: 6.0.2
 appVersion: 2.8.1
 home: https://centrifugal.github.io/centrifugo/
 icon: https://centrifugal.github.io/centrifugo/images/favicon.png

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
             {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
-              value: {{ $value }}
+              value: {{ $value | quote }}
             {{- end }}
           volumeMounts:
             - name: "{{ include "centrifugo.fullname" . }}-config"


### PR DESCRIPTION
Non-string environment values are obsoleted. It is better to quote values on chart level to protect unquoted user input like database number.