### PR TITLE
Fix using existing secret

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 7.0.1
+version: 8.0.0
 appVersion: 3.0.1
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 8.0.0
+version: 7.1.0
 appVersion: 3.0.1
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/_helpers.tpl
+++ b/charts/centrifugo/templates/_helpers.tpl
@@ -119,5 +119,3 @@ imagePullSecrets:
     {{- printf "%s" (include "centrifugo.fullname" .) -}}
 {{- end -}}
 {{- end -}}
-
-

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -70,55 +70,47 @@ spec:
                 secretKeyRef:
                   name: {{ include "centrifugo.secretName" . }}
                   key: admin_secret
-            {{- if .Values.secrets.tokenHmacSecretKey }}
             - name: CENTRIFUGO_TOKEN_HMAC_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "centrifugo.secretName" . }}
                   key: token_hmac_secret_key
-            {{- end }}
-            {{- if .Values.secrets.apiKey }}
+                  optional: true
             - name: CENTRIFUGO_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "centrifugo.secretName" . }}
                   key: api_key
-            {{- end }}
-            {{- if .Values.secrets.grpcApiKey }}
             - name: CENTRIFUGO_GRPC_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "centrifugo.secretName" . }}
                   key: grpc_api_key
-            {{- end }}
-            {{- if .Values.secrets.redisAddress }}
+                  optional: true
             - name: CENTRIFUGO_REDIS_ADDRESS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "centrifugo.secretName" . }}
                   key: redis_address
-            {{- end }}
-            {{- if .Values.secrets.redisPassword }}
+                  optional: true
             - name: CENTRIFUGO_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "centrifugo.secretName" . }}
                   key: redis_password
-            {{- end }}
-            {{- if .Values.secrets.redisSentinelPassword }}
+                  optional: true
             - name: CENTRIFUGO_REDIS_SENTINEL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "centrifugo.secretName" . }}
                   key: redis_sentinel_password
-            {{- end }}
-            {{- if .Values.secrets.natsUrl }}
+                  optional: true
             - name: CENTRIFUGO_NATS_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ include "centrifugo.secretName" . }}
                   key: nats_url
-            {{- end }}
+                  optional: true
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -81,6 +81,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "centrifugo.secretName" . }}
                   key: api_key
+                  optional: true
             - name: CENTRIFUGO_GRPC_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/centrifugo/templates/secret.yaml
+++ b/charts/centrifugo/templates/secret.yaml
@@ -13,8 +13,6 @@ data:
   {{- end }}
   {{- if .Values.secrets.apiKey }}
   api_key: {{ .Values.secrets.apiKey | b64enc | quote }}
-  {{- else }}
-  api_key: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}
   {{- if .Values.secrets.grpcApiKey }}
   grpc_api_key: {{ .Values.secrets.grpcApiKey | b64enc | quote }}

--- a/charts/centrifugo/templates/secret.yaml
+++ b/charts/centrifugo/templates/secret.yaml
@@ -13,6 +13,8 @@ data:
   {{- end }}
   {{- if .Values.secrets.apiKey }}
   api_key: {{ .Values.secrets.apiKey | b64enc | quote }}
+  {{- else }}
+  api_key: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}
   {{- if .Values.secrets.grpcApiKey }}
   grpc_api_key: {{ .Values.secrets.grpcApiKey | b64enc | quote }}


### PR DESCRIPTION
This pull request fixes #17.  It removes checks for whether secrets set in values, since those can come from `existingSecret`.

We can't automatically fill secrets with random values (since `redis_address` will be simply invalid in this case, or `redis_password` will always be used while auth not configured in Redis). To deal with this we use `optional` flag of `secretKeyRef` section. Environment variables will be set but will contain empty values if not found. Empty values in environment variables not handled by Centrifugo thus configuration won't be corrupted if corresponding values are set in `.Values.config`. Ideally would be awesome to not include env vars to pod at all if secret is empty – but don't know a way to do this (maybe with `lookup` func?).

~~I also made `api_key` to be generated automatically to random value. This makes `api_key` to be defined only over secrets since env vars have higher priority in configuration resolution than `.Values.config`. While this seems a good thing in general (as `api_key` is really a secret thing) this can break existing installs that use plain `api_key` in `.Values.config`. Thus chart version got a major version update – v8.0.0.~~ UPD.: I think better to avoid this – see below.
