### PR TITLE
Use networking.k8s.io/v1 for Ingress in k8s >=1.19

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 7.2.4
+version: 7.3.0
 appVersion: 3.1.1
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/ingress.yaml
+++ b/charts/centrifugo/templates/ingress.yaml
@@ -18,10 +18,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "18" ) }}
   {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
-  {{- end }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/centrifugo/templates/ingress.yaml
+++ b/charts/centrifugo/templates/ingress.yaml
@@ -2,10 +2,10 @@
 {{- $fullName := include "centrifugo.fullname" . -}}
 {{- $namespace := include "centrifugo.namespace" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "19" ) }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
@@ -18,6 +18,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "18" ) }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -35,9 +40,19 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            {{- if or ( gt $.Capabilities.KubeVersion.Major "1" ) ( ge $.Capabilities.KubeVersion.Minor "19" ) }}
+            pathType: {{ $.Values.ingress.pathType }}
+            {{- end }}
             backend:
+              {{- if or ( gt $.Capabilities.KubeVersion.Major "1" ) ( ge $.Capabilities.KubeVersion.Minor "19" ) }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -81,6 +81,13 @@ uniGrpcService:
 
 ingress:
   enabled: false
+
+  # Optionally set the ingressClassName. k8s >= 1.18
+  ingressClassName: ""
+
+  # pathType override - see: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+  pathType: Prefix
+
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
Beta APIs (networking.k8s.io/v1beta1) not available anymore.