### PR TITLE
Chart v9 with Centrifugo v4 as base appVersion

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 8.0.0
-appVersion: 3.2.2
+version: 9.0.0
+appVersion: 4.0.0
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png
 maintainers:

--- a/charts/centrifugo/README.md
+++ b/charts/centrifugo/README.md
@@ -225,6 +225,10 @@ Note: it's possible to set Nats URL over secrets if needed.
 
 ## Upgrading
 
+### v8 -> v9
+
+In v9 we are using Centrifugo v4 as base appVersion. See [Centrifugo v4.0.0 release notes](https://github.com/centrifugal/centrifugo/releases/tag/v4.0.0).
+
 ### v7 -> v8
 
 In v8 version we are fixing an inconsistency in `existingSecret` option names reported in [#33](https://github.com/centrifugal/helm-charts/issues/33).


### PR DESCRIPTION
In v9 we are using Centrifugo v4 as base appVersion. See [Centrifugo v4.0.0 release notes](https://github.com/centrifugal/centrifugo/releases/tag/v4.0.0).