### PR TITLE
add Autoscaling/v2 support

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 9.1.2
+version: 9.1.3
 appVersion: 4.1.2
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/hpa.yaml
+++ b/charts/centrifugo/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+apiVersion: "autoscaling/v2"
+{{- else }}
+apiVersion: "autoscaling/v2beta1"
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "centrifugo.fullname" . }}
@@ -18,12 +22,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
   {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The autoscaling/v2beta1 API version of HorizontalPodAutoscaler is no longer served as of v1.25.
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125