### PR TITLE
Add initContainers

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 9.1.5
+version: 9.1.6
 appVersion: 4.1.3
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/README.md
+++ b/charts/centrifugo/README.md
@@ -97,6 +97,7 @@ The following table lists the configurable parameters of the Centrifugo chart an
 | `env`                                       | Additional environment variables to be passed to Centrifugo container.                                                  | `nil`                                                        |
 | `config`                                    | Centrifugo configuration, will be transformed into config.json file                                                     | `{"admin":true,"engine":"memory","namespaces":[],"v3_use_offset":true}`                                                        |
 | `existingSecret`                            | Name of existing secret to use for secret's parameters. The secret has to contain the keys below                        | `nil`                                                         |
+| `initContainers`                             | Set initContainers, e.g. wait for other resources                                                                      | `nil`                                                         |
 | `secrets.tokenHmacSecretKey`                 | Secret key for HMAC tokens.                                                                                             | `nil`                                                         |
 | `secrets.adminPassword`                      | Admin password used to protect access to web interface.                                                                 | `nil`                                                         |
 | `secrets.adminSecret`                        | Admin secret used to create auth tokens on user login into admin web interface.                                         | `nil`                                                         |
@@ -222,6 +223,44 @@ helm install centrifugo -f values.yaml ./centrifugo --set config.broker=nats --s
 ```
 
 Note: it's possible to set Nats URL over secrets if needed.
+
+## Using initContainers
+
+You can define `initContainers` in your values.yaml to wait for other resources or to do some init jobs. `initContainers` might be useful to wait for your engine to be ready before starting centrifugo.
+
+### Redis
+
+```yaml
+initContainers:
+  - name: wait-for-redis
+    image: ghcr.io/patrickdappollonio/wait-for:latest
+    env:
+    - name: REDIS_ADDRESS
+      value: "redis:6379"
+    command:
+      - /wait-for
+    args:
+      - --host="$(REDIS_ADDRESS)"
+      - --timeout=240s
+      - --verbose
+```
+
+### Example Nats
+
+```yaml
+initContainers:
+  - name: wait-for-nats
+    image: ghcr.io/patrickdappollonio/wait-for:latest
+    env:
+    - name: NATS_ADDRESS
+      value: "nats:4222"
+    command:
+      - /wait-for
+    args:
+      - --host="$(NATS_ADDRESS)"
+      - --timeout=240s
+      - --verbose
+```
 
 ## Upgrading
 

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,6 +43,12 @@ spec:
         - name: {{ include "centrifugo.fullname" . }}-config
           configMap:
             name: {{ include "centrifugo.fullname" . }}-config  
+      {{- if .Values.initContainers}}
+      initContainers:
+        {{- with .Values.initContainers }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -241,6 +241,11 @@ config:
   # Array of namespaces.
   namespaces: []
 
+
+# Init Containers, e.g. for waiting for other resources like redis  (evaluated as template)
+# see https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+initContainers: ""
+
 # existingSecret: my-secret
 
 # Centrifugo secrets.


### PR DESCRIPTION
Hi,

We have been using Centrifugo for a few weeks now and have the case, where Centrifugo should start after some other pods (our Core and Redis) have become ready. For Redis, I think this is a generally good case to avoid `CrashLoopBack`ing Centrifugo while Redis is starting.

I added a simple `initContainers` functionality that allows to add arbitrary `initContainers` and added 2 examples for NATS and Redis in the readme.

Cheers
Dennis

