### PR TITLE
Added ability to use topologySpreadConstraints

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 11.0.0
+version: 11.0.1
 appVersion: 5.0.2
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -31,6 +31,12 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- with .Values.topologySpreadConstraints }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -264,6 +264,10 @@ config:
   namespaces: []
 
 
+# TopologySpreadConstrains, e.g. for spreading pods across nodes
+# see https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+topologySpreadConstraints: ""
+
 # Init Containers, e.g. for waiting for other resources like redis  (evaluated as template)
 # see https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 initContainers: ""


### PR DESCRIPTION
I think that official motivation is good enough. https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#motivation

Imagine that you have a cluster of up to twenty nodes, and you want to run a [workload](https://kubernetes.io/docs/concepts/workloads/) that automatically scales how many replicas it uses. There could be as few as two Pods or as many as fifteen. When there are only two Pods, you'd prefer not to have both of those Pods run on the same node: you would run the risk that a single node failure takes your workload offline.

Short: We need that functionality to spread pods across AZ in AWS. 
