### PR TITLE
Add support for additinal service labels

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 11.0.4
+version: 11.0.5
 appVersion: 5.0.3
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/service-grpc-api.yaml
+++ b/charts/centrifugo/templates/service-grpc-api.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "centrifugo.namespace" . }}
   labels:
     {{- include "centrifugo.labels" . | nindent 4 }}
+    {{- with .Values.grpcService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.grpcService.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/centrifugo/templates/service-internal.yaml
+++ b/charts/centrifugo/templates/service-internal.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "centrifugo.namespace" . }}
   labels:
     {{- include "centrifugo.labels" . | nindent 4 }}
+    {{- with .Values.internalService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.internalService.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/centrifugo/templates/service-uni-grpc.yaml
+++ b/charts/centrifugo/templates/service-uni-grpc.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "centrifugo.namespace" . }}
   labels:
     {{- include "centrifugo.labels" . | nindent 4 }}
+    {{- with .Values.uniGrpcService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.uniGrpcService.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/centrifugo/templates/service.yaml
+++ b/charts/centrifugo/templates/service.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ include "centrifugo.namespace" . }}
   labels:
     {{- include "centrifugo.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -36,6 +36,9 @@ service:
   ## Provide any additional annotations which may be required
   ##
   annotations: {}
+  ## Provide any additional labels which may be required
+  ##
+  labels: {}
   ##
   ## Specify custom appProtocol for a service port.
   appProtocol: ""
@@ -58,6 +61,7 @@ internalService:
     # prometheus.io/path: "/metrics"
     # prometheus.io/port: "9000"
   ## Specify custom appProtocol for a service port.
+  labels: {}
   appProtocol: ""
 
 grpcService:
@@ -68,6 +72,7 @@ grpcService:
   # nodePort: 30102
   annotations: {}
   ## Specify custom appProtocol for a service port.
+  labels: {}
   appProtocol: ""
 
 uniGrpcService:
@@ -78,6 +83,7 @@ uniGrpcService:
   # nodePort: 30103
   annotations: {}
   ## Specify custom appProtocol for a service port.
+  labels: {}
   appProtocol: ""
 
 ingress:


### PR DESCRIPTION
We use the helm-chart in conjunction with Spring-Cloud-Kubernetes. Furthermore, we use Spring-Cloud-Open-Feign to publish messages to Centrifugo. Spring uses a [DiscoveryClient for Kubernetes](https://docs.spring.io/spring-cloud-kubernetes/docs/current/reference/html/#discoveryclient-for-kubernetes) which tells Feign where the request should be routed to. As Centrifugo - by default - uses a single service with many ports, Spring does not know to which port the request should be sent. However, Spring allows to add a Label to a Service whose value should be the service port Feign will use: See the Spring docs for `primary-port-name`. With this change, it's possible to add 
```
service:
  labels: 
    primary-port-name: "internal"
```
to the `values` yaml, making the Feign client work. 