### PR TITLE
add possibility for customizing dnsconfig

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 11.0.9
+version: 11.0.10
 appVersion: 5.1.0
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -189,3 +189,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+        {{- with .Values.dnsConfig }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -252,6 +252,10 @@ tolerations: []
 
 affinity: {}
 
+## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+dnsPolicy: ""
+dnsConfig: {}
+
 # Additional environment variables to be passed to Centrifugo container.
 env: {}
 


### PR DESCRIPTION
I faced with the issue of extra latency withing communication with redis-sentinel cluster.

I was related to poor internal dns performance.

Such option allows to customize `resolve.conf` inside pod to use node-local-dns (https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/#motivation)  