### PR TITLE
Allow specification of liveness & readiness probes schemes

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 11.2.0
+version: 11.2.1
 appVersion: 5.1.2
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -167,12 +167,14 @@ spec:
             httpGet:
               path: /health
               port: {{ .Values.internalService.port }}
+              scheme: {{ .Values.internalService.probeScheme }}
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /health
               port: {{ .Values.internalService.port }}
+              scheme: {{ .Values.internalService.probeScheme }}
             initialDelaySeconds: 3
             periodSeconds: 10
           resources:

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -53,6 +53,7 @@ service:
 internalService:
   port: 9000
   type: ClusterIP
+  probeScheme: HTTP
   nodePort: ""
   # Static NodePort, if set.
   # nodePort: 30101


### PR DESCRIPTION
Currently when enabling tls=true in the Centrifugo's config liveness and readiness probes also start serving using https. This PR adds ability to manage http probes' scheme (i.e. set it to HTTPS in case of enabled tls).