### PR TITLE
Apply tpl function for secretKeyRef section of envSecret vars

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 11.4.1
+version: 11.5.0
 appVersion: 5.2.2
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 11.5.0
+version: 11.6.0
 appVersion: 5.2.2
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -145,7 +145,7 @@ spec:
             - name: {{ .name }}
               valueFrom:
                 secretKeyRef: 
-                  {{- toYaml .secretKeyRef | nindent 18 }}
+                  {{- tpl (toYaml .secretKeyRef) $ | nindent 18 }}
             {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -6,6 +6,12 @@ metadata:
   namespace: {{ include "centrifugo.namespace" . }}
   labels:
     {{- include "centrifugo.labels" . | nindent 4 }}
+  {{- if .Values.annotations }}
+  annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -6,11 +6,9 @@ metadata:
   namespace: {{ include "centrifugo.namespace" . }}
   labels:
     {{- include "centrifugo.labels" . | nindent 4 }}
-  {{- if .Values.annotations }}
+  {{- with .Values.annotations }}
   annotations:
-    {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -21,6 +21,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 priorityClassName: ""
+annotations: {}
 
 service:
   ## Service type

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -21,6 +21,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 priorityClassName: ""
+# Annotations to be added to the deployment
 annotations: {}
 
 service:


### PR DESCRIPTION
There are some cases when templating on the "values" level is useful. I will describe our cases below.

The first one is when the chart is included as subchart with some other charts, e.g. Redis helm chart. In that case, the redis service URL looks as follows "{{ .Release.Name }}-redis". You would like to get rid of the hardcode in values here.
```
  ...
config:
  engine: "redis"
  redis_sentinel_address: "{{.Release.Name}}-redis:26379"
```

The second example is when you need to provide additional envSecrets. In our case, we create the secret in a subchart as a result its name depends as well on the release name.
```
...
envSecret:
  - name: CENTRIFUGO_TOKEN_ECDSA_PUBLIC_KEY
    secretKeyRef:
      name: "{{ .Release.Name }}"
      key: token_ecdsa_public_key
```

The MR is intended to cover the cases above. Hopefully, it doesn't contradict the current approach.