### PR TITLE
fix: disabling automatic creation of adminPassword and adminSecret

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 11.8.8
+version: 11.8.9
 appVersion: 5.4.8
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/secret.yaml
+++ b/charts/centrifugo/templates/secret.yaml
@@ -17,15 +17,17 @@ data:
   {{- if .Values.secrets.grpcApiKey }}
   grpcApiKey: {{ .Values.secrets.grpcApiKey | b64enc | quote }}
   {{- end }}
-  {{- if .Values.secrets.adminPassword }}
-  adminPassword: {{ .Values.secrets.adminPassword | b64enc | quote }}
-  {{- else }}
-  adminPassword: {{ randAlphaNum 12 | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.secrets.adminSecret }}
-  adminSecret: {{ .Values.secrets.adminSecret | b64enc | quote }}
-  {{- else }}
-  adminSecret: {{ randAlphaNum 24 | b64enc | quote }}
+  {{- if.Values.config.admin }}
+    {{- if.Values.secrets.adminPassword }}
+    adminPassword: {{.Values.secrets.adminPassword | b64enc | quote }}
+    {{- else }}
+    adminPassword: {{ randAlphaNum 12 | b64enc | quote }}
+    {{- end }}
+    {{- if.Values.secrets.adminSecret }}
+    adminSecret: {{.Values.secrets.adminSecret | b64enc | quote }}
+    {{- else }}
+    adminSecret: {{ randAlphaNum 24 | b64enc | quote }}
+    {{- end }}
   {{- end }}
   {{- if .Values.secrets.redisAddress }}
   redisAddress: {{ .Values.secrets.redisAddress | b64enc | quote }}

--- a/charts/centrifugo/templates/secret.yaml
+++ b/charts/centrifugo/templates/secret.yaml
@@ -17,14 +17,14 @@ data:
   {{- if .Values.secrets.grpcApiKey }}
   grpcApiKey: {{ .Values.secrets.grpcApiKey | b64enc | quote }}
   {{- end }}
-  {{- if.Values.config.admin }}
-  {{- if.Values.secrets.adminPassword }}
-  adminPassword: {{.Values.secrets.adminPassword | b64enc | quote }}
+  {{- if .Values.config.admin }}
+  {{- if .Values.secrets.adminPassword }}
+  adminPassword: {{ .Values.secrets.adminPassword | b64enc | quote }}
   {{- else }}
   adminPassword: {{ randAlphaNum 12 | b64enc | quote }}
   {{- end }}
-  {{- if.Values.secrets.adminSecret }}
-  adminSecret: {{.Values.secrets.adminSecret | b64enc | quote }}
+  {{- if .Values.secrets.adminSecret }}
+  adminSecret: {{ .Values.secrets.adminSecret | b64enc | quote }}
   {{- else }}
   adminSecret: {{ randAlphaNum 24 | b64enc | quote }}
   {{- end }}

--- a/charts/centrifugo/templates/secret.yaml
+++ b/charts/centrifugo/templates/secret.yaml
@@ -18,16 +18,16 @@ data:
   grpcApiKey: {{ .Values.secrets.grpcApiKey | b64enc | quote }}
   {{- end }}
   {{- if.Values.config.admin }}
-    {{- if.Values.secrets.adminPassword }}
-    adminPassword: {{.Values.secrets.adminPassword | b64enc | quote }}
-    {{- else }}
-    adminPassword: {{ randAlphaNum 12 | b64enc | quote }}
-    {{- end }}
-    {{- if.Values.secrets.adminSecret }}
-    adminSecret: {{.Values.secrets.adminSecret | b64enc | quote }}
-    {{- else }}
-    adminSecret: {{ randAlphaNum 24 | b64enc | quote }}
-    {{- end }}
+  {{- if.Values.secrets.adminPassword }}
+  adminPassword: {{.Values.secrets.adminPassword | b64enc | quote }}
+  {{- else }}
+  adminPassword: {{ randAlphaNum 12 | b64enc | quote }}
+  {{- end }}
+  {{- if.Values.secrets.adminSecret }}
+  adminSecret: {{.Values.secrets.adminSecret | b64enc | quote }}
+  {{- else }}
+  adminSecret: {{ randAlphaNum 24 | b64enc | quote }}
+  {{- end }}
   {{- end }}
   {{- if .Values.secrets.redisAddress }}
   redisAddress: {{ .Values.secrets.redisAddress | b64enc | quote }}


### PR DESCRIPTION
Disabling automatic creation of adminPassword and adminSecret when the admin panel is disabled
--------------------------------------------------------------------------------------------------------------------------
When you re-deploy the centrifugo with the admin panel turned off, adminPassword and adminSecret are recreated, which leads to a restart of the centrifugo
--------------------------------------------------------------------------------------------------------------------------