### PR TITLE
Add hostCheck Pre-Deployment Job for DNS Validation

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 11.8.9
+version: 11.8.10
 appVersion: 5.4.9
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/hooks/dns-check.yaml
+++ b/charts/centrifugo/templates/hooks/dns-check.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.hostCheck.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "centrifugo.fullname" . }}-host-check
+  namespace: {{ include "centrifugo.namespace" . }}
+  labels:
+    {{- include "centrifugo.labels" . | nindent 4 }}
+    tier: host-check
+  annotations:
+    {{- if .Values.hostCheck.annotations }}
+    {{- toYaml .Values.hostCheck.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "centrifugo.labels" . | nindent 8 }}
+        tier: host-check
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: host-checker
+          image: "{{ .Values.hostCheck.image }}"
+          env:
+            - name: REMOTE_HOST
+              value: "{{ .Values.hostCheck.remoteHost }}"
+            {{- if .Values.hostCheck.customDns }}
+            - name: CUSTOM_DNS
+              value: "{{ .Values.hostCheck.customDns }}"
+            {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Starting DNS validation for $REMOTE_HOST..."
+              DNS_NAME=$REMOTE_HOST
+              MAX_RETRIES=10
+              RETRY_COUNT=0
+              BACKOFF=2 # Initial backoff in seconds
+
+              resolve_dns() {
+                local dns_server=$1
+                if [ -z "$dns_server" ]; then
+                  dig +short $DNS_NAME A 2>/dev/null | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'
+                else
+                  dig +short $DNS_NAME A @$dns_server 2>/dev/null | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'
+                fi
+              }
+
+              while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+                echo ""
+                echo "Attempt $((RETRY_COUNT + 1)): Resolving $DNS_NAME..."
+
+                # Default DNS resolution
+                echo "Using default DNS server to resolve $DNS_NAME..."
+                RESOLVED_DEFAULT=$(resolve_dns "")
+                if [ -z "$RESOLVED_DEFAULT" ]; then
+                  echo "Default DNS resolution failed for $DNS_NAME."
+                else
+                  echo "Default DNS resolution successful: $DNS_NAME resolved to:"
+                  echo "$RESOLVED_DEFAULT"
+                fi
+
+                # Custom DNS resolution (only if CUSTOM_DNS is provided)
+                if [ -n "$CUSTOM_DNS" ]; then
+                  echo "Using custom DNS server ($CUSTOM_DNS) to resolve $DNS_NAME..."
+                  RESOLVED_CUSTOM=$(resolve_dns "$CUSTOM_DNS")
+                  if [ -z "$RESOLVED_CUSTOM" ]; then
+                    echo "Custom DNS resolution failed for $DNS_NAME using $CUSTOM_DNS."
+                  else
+                    echo "Custom DNS resolution successful: $DNS_NAME resolved to:"
+                    echo "$RESOLVED_CUSTOM"
+                  fi
+                fi
+
+                # Check success conditions
+                if [ -n "$RESOLVED_DEFAULT" ] && { [ -z "$CUSTOM_DNS" ] || [ -n "$RESOLVED_CUSTOM" ]; }; then
+                  echo ""
+                  echo "DNS resolution successful using the required DNS servers."
+                  exit 0
+                fi
+
+                # Retry logic
+                echo "Retrying in $BACKOFF seconds..."
+                sleep $BACKOFF
+                BACKOFF=$((BACKOFF * 2)) # Exponential backoff
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+              done
+
+              echo ""
+              echo "DNS resolution failed for the required DNS servers after $MAX_RETRIES attempts."
+              exit 1
+          resources:
+            {{- toYaml .Values.hostCheck.resources | nindent 12 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      activeDeadlineSeconds: 300
+  backoffLimit: 2
+{{- end }}

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -332,3 +332,29 @@ secrets:
 
   # Centrifugo PRO license.
   license: ""
+
+  # Configuration for the hostCheck pre-installation/pre-upgrade job.
+  # This job is used to validate DNS resolution for a specific remote host
+  # using both default and custom DNS servers (if provided).
+  # It can help ensure that external dependencies or services
+  # are accessible before proceeding with the deployment.
+hostCheck:
+  enabled: false
+  # Docker image used for the host check job
+  # Ensure this image has the necessary tools (e.g., dig) to perform DNS checks, for ex. registry.k8s.io/e2e-test-images/agnhost:2.39
+  image: ""
+  # Custom DNS server to use for host resolution (e.g., 8.8.8.8 for Google DNS)
+  # If not provided, only the default DNS server will be used
+  customDns: ""
+  # The remote host that the DNS resolution check will target
+  # Replace this with the hostname you want to validate
+  remoteHost: ""
+  # Define or override annotations
+  # Examples:
+  # "helm.sh/hook": pre-install,pre-upgrade
+  # "helm.sh/hook-weight": "-1"
+  # "helm.sh/hook-delete-policy": before-hook-creation
+  annotations: {}
+  # Resources configuration for the host check job's pod
+  # You can specify CPU, memory requests, and limits here
+  resources: {}


### PR DESCRIPTION
This PR introduces a configurable hostCheck feature to the chart. The hostCheck is a (pre-installation/pre-upgrade) job designed to validate DNS resolution for a specified remote host. This helps to ensure that external dependencies or services required by the application are reachable before proceeding with the deployment.
Host check is particularly useful for deployments that rely on external services, APIs. It provides an early warning for potential issues, improving the reliability of the deployment process.
Let me know if any additional information or changes are needed!





