### PR TITLE
Adding support for extraContainers

### DIFF
--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -190,7 +190,9 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 10
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.extraContainers }}
+        {{- toYaml .Values.extraContainers | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -223,6 +223,10 @@ deploymentStrategy: {}
   #   maxSurge: 0
   #   maxUnavailable: 1
 
+extraContainers: []
+#  - name: my-sidecar
+#    image: nginx:latest
+
 metrics:
   enabled: false
   serviceMonitor:


### PR DESCRIPTION
Hello.

This PR adds support for injecting extra containers into the Centrifugo pod through the Helm chart. 
In our environment, we use gRPC listeners that need to be placed alongside the сentrifugo pod. This change makes it possible.
