### PR TITLE
Correct documentation link about engine

### DIFF
--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -273,7 +273,7 @@ envSecret: []
 config:
   # Engine to use. Default memory engine allows running only one Centrifugo pod.
   # Scale to many pods with Redis engine or Nats broker. Refer to Centrifugo
-  # documentation: https://centrifugal.github.io/centrifugo/server/engines/
+  # documentation: https://centrifugal.dev/docs/server/engines
   engine:
     type: "memory"
 


### PR DESCRIPTION
The current link for engine returns 404, I updated it with the new link.