### PR TITLE
Revise workflows and support OCI chart repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,17 +14,17 @@ jobs:
 
       - name: Run chart-testing (lint)
         id: lint
-        uses: helm/chart-testing-action@v1.0.0
+        uses: helm/chart-testing-action@v2.7.0
         with:
           command: lint
           config: ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.12.0
         if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0
+        uses: helm/chart-testing-action@v2.7.0
         with:
           command: install
           config: ct.yaml

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         id: lint
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
           config: ct.yaml
@@ -24,7 +24,7 @@ jobs:
         if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@v1.0.0
         with:
           command: install
           config: ct.yaml

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Fetch history
         run: git fetch --prune --unshallow

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Lint Code Base
         uses: docker://github/super-linter:v3.12.0
         env:

--- a/.github/workflows/release-http.yaml
+++ b/.github/workflows/release-http.yaml
@@ -1,4 +1,4 @@
-name: Release Charts
+name: Tag and Release Charts on HTTP
 
 on:
   push:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Fetch history
         run: git fetch --prune --unshallow
@@ -20,14 +20,10 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      # See https://github.com/helm/chart-releaser-action/issues/6
-      - name: Install Helm
-        run: |
-          curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-          chmod 700 get_helm.sh
-          ./get_helm.sh
+      - name: Set up helm
+        uses: azure/setup-helm@v4
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-oci.yaml
+++ b/.github/workflows/release-oci.yaml
@@ -1,0 +1,32 @@
+name: Release Charts on OCI
+
+on:
+  push:
+    tags:
+      - "centrifugo-*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Set up helm
+        uses: azure/setup-helm@v4
+
+      - name: login to github container registry using helm
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io/centrifugal/helm-charts --username ${{ github.repository_owner }} --password-stdin
+
+      - name: package centrifugo helm chart
+        run: |
+          helm package ./charts/centrifugo
+
+      - name: publish centrifugo chart to github container registry
+        run: |
+          version=${{ github.ref_name }}
+          helm push "${version}".tgz oci://ghcr.io/centrifugal/helm-charts/centrifugo


### PR DESCRIPTION
Based on #117, I've revise workflows:

- Use same `.yaml` extension over all the workflows
- Use a dependabot to upgrade workflows
- Upgrade current stages and use `azure/install-helm` to install helm

Then, I added another stage which will be call on tag (Tagging part is already done using `helm-release-action`) and push the same chart into Github container registry.