### PR TITLE
Add conditional rendering for clusterIP in gRPC Service template

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
-version: 12.5.0
+version: 12.6.0
 appVersion: 6.4.0
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/service-grpc-api.yaml
+++ b/charts/centrifugo/templates/service-grpc-api.yaml
@@ -15,6 +15,11 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.grpcService.type }}
+  {{- if (eq .Values.grpcService.type "ClusterIP") }}
+  {{- with .Values.grpcService.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- end }}
   ports:
     - port: {{ .Values.grpcService.port }}
       targetPort: grpc


### PR DESCRIPTION
Hello.

This PR introduces support for configuring headless gRPC Services (clusterIP: None), allowing gRPC clients to perform DNS-based client-side load balancing across multiple Pods.