### PR TITLE
fix(ingressInternal): use internal service when serviceInternal.useSeparate is true

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
 type: application
-version: 13.2.1
+version: 13.2.2
 appVersion: 6.8.1
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/ingress-internal.yaml
+++ b/charts/centrifugo/templates/ingress-internal.yaml
@@ -47,7 +47,7 @@ spec:
             backend:
               {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
-                {{- if $.Values.serviceInternal.enabled }}
+                {{- if or $.Values.serviceInternal.enabled $.Values.serviceInternal.useSeparate }}
                 name: {{ $fullName }}-internal
                 {{- else }}
                 name: {{ $fullName }}
@@ -55,7 +55,7 @@ spec:
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              {{- if $.Values.serviceInternal.enabled }}
+              {{- if or $.Values.serviceInternal.enabled $.Values.serviceInternal.useSeparate }}
               serviceName: {{ $fullName }}-internal
               {{- else }}
               serviceName: {{ $fullName }}

--- a/charts/centrifugo/templates/ingress-internal.yaml
+++ b/charts/centrifugo/templates/ingress-internal.yaml
@@ -47,7 +47,7 @@ spec:
             backend:
               {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
-                {{- if or $.Values.serviceInternal.enabled $.Values.serviceInternal.useSeparate }}
+                {{- if $.Values.serviceInternal.useSeparate }}
                 name: {{ $fullName }}-internal
                 {{- else }}
                 name: {{ $fullName }}
@@ -55,7 +55,7 @@ spec:
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              {{- if or $.Values.serviceInternal.enabled $.Values.serviceInternal.useSeparate }}
+              {{- if $.Values.serviceInternal.useSeparate }}
               serviceName: {{ $fullName }}-internal
               {{- else }}
               serviceName: {{ $fullName }}


### PR DESCRIPTION
With a combination of `ingressInternal.enabled=true` and `serviceInternal.useSeparate=true` I need to add `serviceInternal.enabled=true` as well, which is really unexpected. As I see it, this variable is only used in internal ingress, looks like a small error.

I suppose it would be more correct to completely remove this variable, but perhaps backward compatibility is preferable. If you don't mind, I can delete it.