### PR TITLE
Out-of-the-box Istio / service-mesh support via appProtocol defaults

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,36 @@
+---
+###########################
+###########################
+## Markdown Linter rules ##
+###########################
+###########################
+
+# Linter rules doc:
+# - https://github.com/DavidAnson/markdownlint
+#
+# Note:
+# To comment out a single error:
+#   <!-- markdownlint-disable -->
+#   any violations you want
+#   <!-- markdownlint-restore -->
+#
+
+###############
+# Rules by id #
+###############
+MD004: false # Unordered list style
+MD007:
+  indent: 2 # Unordered list indentation
+MD013:
+  line_length: 400 # Line length 80 is far too short
+MD026:
+  punctuation: ".,;:!。，；:" # List of not allowed
+MD029: false # Ordered list item prefix
+MD033: false # Allow inline HTML
+MD036: false # Emphasis used instead of a heading
+MD060: false # Table column style: cosmetic rule flags long-standing table formatting
+
+#################
+# Rules by tags #
+#################
+blank_lines: false # Error on blank lines

--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
 type: application
-version: 13.3.2
+version: 13.4.0
 appVersion: 6.8.4
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/README.md
+++ b/charts/centrifugo/README.md
@@ -692,13 +692,20 @@ In both cases the chart only needs `gateway`/`httpRoute` values; the cloud polic
 
 Centrifugo runs under a service mesh with **no extra configuration** — WebSocket, HTTP streaming/SSE and emulation on the external port, the HTTP/gRPC server APIs, and the unidirectional gRPC stream all work out of the box.
 
-This works because every Service port declares its L7 protocol through the standard [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field (`http` for the external and internal ports, `grpc` for the gRPC ports — see [Service Parameters](#service-parameters) to override). A mesh reads `appProtocol` directly, so it classifies each port deterministically instead of guessing.
+This works because every Service port declares its L7 protocol through the standard [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field
+(`http` for the external and internal ports, `grpc` for the gRPC ports — see [Service Parameters](#service-parameters) to override).
+A mesh reads `appProtocol` directly, so it classifies each port deterministically instead of guessing.
 
-**Why it matters.** Without `appProtocol`, Istio falls back to byte-level [protocol sniffing](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/). For a bidirectional WebSocket that opens with a client-sent HTTP `Upgrade` this usually works, but detection is best-effort and adds latency: Istio installs both an HTTP filter chain *and* a plain-TCP fallback on the port, and traffic that isn't recognized in time drops to raw TCP (losing WebSocket/HTTP handling). This is the intermittent behavior — connections settling only after a delay — originally reported in [#23](https://github.com/centrifugal/helm-charts/issues/23). Declaring `appProtocol` removes the guesswork: the external port becomes an unconditional HTTP listener, and Istio passes WebSocket upgrades and does not buffer SSE/streaming responses.
+**Why it matters.** Without `appProtocol`, Istio falls back to byte-level [protocol sniffing](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/).
+For a bidirectional WebSocket that opens with a client-sent HTTP `Upgrade` this usually works, but detection is best-effort and adds latency: Istio installs both an HTTP filter chain _and_ a plain-TCP fallback on the port, and traffic that isn't recognized in time drops to raw TCP (losing WebSocket/HTTP handling).
+This is the intermittent behavior — connections settling only after a delay — originally reported in [#23](https://github.com/centrifugal/helm-charts/issues/23).
+Declaring `appProtocol` removes the guesswork: the external port becomes an unconditional HTTP listener, and Istio passes WebSocket upgrades and does not buffer SSE/streaming responses.
 
 > Verified on Istio (sidecar + ingress gateway): with the chart defaults the external port is programmed as a single HTTP filter chain (no TCP fallback), and a WebSocket completes through the mesh — client sidecar → mTLS → server sidecar → Centrifugo. Removing `appProtocol` brings the sniffing/TCP-fallback chain back.
 
-**WebSocket over HTTP/2.** By default the external port speaks HTTP/1.1, and WebSocket traverses the mesh over HTTP/1.1 — which is exactly what `appProtocol: http` describes. Clients that could use [WebSocket over HTTP/2 (RFC 8441)](https://centrifugal.dev/docs/transports/websocket#websocket-over-http2-rfc-8441) fall back to HTTP/1.1 automatically, because a client may only attempt Extended CONNECT when the edge advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL`, which Istio does not do by default. An HTTP/2 ingress listener therefore keeps serving HTTP/2 for ordinary requests while WebSocket uses HTTP/1.1 — both coexist with no extra config.
+**WebSocket over HTTP/2.** By default the external port speaks HTTP/1.1, and WebSocket traverses the mesh over HTTP/1.1 — which is exactly what `appProtocol: http` describes.
+Clients that could use [WebSocket over HTTP/2 (RFC 8441)](https://centrifugal.dev/docs/transports/websocket#websocket-over-http2-rfc-8441) fall back to HTTP/1.1 automatically, because a client may only attempt Extended CONNECT when the edge advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL`, which Istio does not do by default.
+An HTTP/2 ingress listener therefore keeps serving HTTP/2 for ordinary requests while WebSocket uses HTTP/1.1 — both coexist with no extra config.
 
 If you want true WebSocket-over-HTTP/2 end-to-end, it is opt-in on both sides: enable it on Centrifugo (TLS or `http_server.h2c_external`, plus the `GODEBUG=http2xconnect=1` runtime flag), set the external port's `appProtocol` to `http2`, and enable Extended CONNECT on the mesh — currently an `EnvoyFilter` setting `allow_connect`, as there is no Istio-native switch yet ([istio/istio#55680](https://github.com/istio/istio/discussions/55680)).
 
@@ -1381,10 +1388,13 @@ initContainers:
 | `serviceUniGrpc.port` | Uni GRPC service port | `11000` |
 | `serviceUniGrpc.appProtocol` | appProtocol for the unidirectional GRPC port | `grpc` |
 
-Each service port advertises its L7 protocol via the standard Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field so a service mesh (Istio, Linkerd, …) routes it correctly out of the box — no manual protocol hints required. The external port defaults to `http` because Centrifugo serves it over HTTP/1.1 (WebSocket, HTTP streaming/SSE, emulation), and Istio's `http` protocol passes WebSocket upgrades and does not buffer streaming responses. `appProtocol` is ignored by plain kube-proxy, so non-mesh clusters are unaffected. Set an `appProtocol` to `""` to omit the field, or override it when a port runs differently:
+Each service port advertises its L7 protocol via the standard Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field so a service mesh (Istio, Linkerd, …) routes it correctly out of the box — no manual protocol hints required.
+The external port defaults to `http` because Centrifugo serves it over HTTP/1.1 (WebSocket, HTTP streaming/SSE, emulation), and Istio's `http` protocol passes WebSocket upgrades and does not buffer streaming responses.
+`appProtocol` is ignored by plain kube-proxy, so non-mesh clusters are unaffected. Set an `appProtocol` to `""` to omit the field, or override it when a port runs differently:
 
 - `https` — if Centrifugo terminates TLS on the external port itself.
-- `http2` — if you enable Centrifugo's [WebSocket over HTTP/2 (RFC 8441)](https://centrifugal.dev/docs/transports/websocket#websocket-over-http2-rfc-8441). That transport also requires TLS or `http_server.h2c_external` on Centrifugo, and forwarding WebSocket-over-HTTP/2 through Istio needs Extended CONNECT enabled on the mesh (an `EnvoyFilter` setting `allow_connect`; there is no Istio-native switch yet — see [istio/istio#55680](https://github.com/istio/istio/discussions/55680)).
+- `http2` — if you enable Centrifugo's [WebSocket over HTTP/2 (RFC 8441)](https://centrifugal.dev/docs/transports/websocket#websocket-over-http2-rfc-8441).
+  That transport also requires TLS or `http_server.h2c_external` on Centrifugo, and forwarding WebSocket-over-HTTP/2 through Istio needs Extended CONNECT enabled on the mesh (an `EnvoyFilter` setting `allow_connect`; there is no Istio-native switch yet — see [istio/istio#55680](https://github.com/istio/istio/discussions/55680)).
 
 ### Metrics Parameters
 

--- a/charts/centrifugo/README.md
+++ b/charts/centrifugo/README.md
@@ -24,6 +24,7 @@ For Centrifugo configuration options, see the [official documentation](https://c
     - [AWS ALB Ingress (EKS)](#aws-alb-ingress-eks)
     - [GCP GKE Ingress](#gcp-gke-ingress)
   - [Gateway API (HTTPRoute)](#gateway-api-httproute)
+  - [Service Mesh (Istio)](#service-mesh-istio)
 - [Production Deployment](#production-deployment)
   - [Resource Considerations](#resource-considerations)
   - [High Availability Example](#high-availability-example)
@@ -686,6 +687,20 @@ In both cases the chart only needs `gateway`/`httpRoute` values; the cloud polic
 - **Hostname intersection:** a Gateway listener `hostname` and the HTTPRoute `hostnames` must intersect, or the route will not bind. Keep them consistent.
 - **Cross-namespace attachment:** if the route and the Gateway live in different namespaces (you set `gateway.namespace`, or reference an external Gateway), the Gateway's listener `allowedRoutes.namespaces` must permit the route's namespace. The backend Service is always in the release namespace, so no `ReferenceGrant` is needed for it (a TLS `certificateRefs` resolving across namespaces would).
 - **Exposing internal endpoints:** as with `ingressInternal`, be careful with `httpRouteInternal` — it can expose admin, server API, metrics and health endpoints. Restrict access at the Gateway.
+
+### Service Mesh (Istio)
+
+Centrifugo runs under a service mesh with **no extra configuration** — WebSocket, HTTP streaming/SSE and emulation on the external port, the HTTP/gRPC server APIs, and the unidirectional gRPC stream all work out of the box.
+
+This works because every Service port declares its L7 protocol through the standard [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field (`http` for the external and internal ports, `grpc` for the gRPC ports — see [Service Parameters](#service-parameters) to override). A mesh reads `appProtocol` directly, so it classifies each port deterministically instead of guessing.
+
+**Why it matters.** Without `appProtocol`, Istio falls back to byte-level [protocol sniffing](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/). For a bidirectional WebSocket that opens with a client-sent HTTP `Upgrade` this usually works, but detection is best-effort and adds latency: Istio installs both an HTTP filter chain *and* a plain-TCP fallback on the port, and traffic that isn't recognized in time drops to raw TCP (losing WebSocket/HTTP handling). This is the intermittent behavior — connections settling only after a delay — originally reported in [#23](https://github.com/centrifugal/helm-charts/issues/23). Declaring `appProtocol` removes the guesswork: the external port becomes an unconditional HTTP listener, and Istio passes WebSocket upgrades and does not buffer SSE/streaming responses.
+
+> Verified on Istio (sidecar + ingress gateway): with the chart defaults the external port is programmed as a single HTTP filter chain (no TCP fallback), and a WebSocket completes through the mesh — client sidecar → mTLS → server sidecar → Centrifugo. Removing `appProtocol` brings the sniffing/TCP-fallback chain back.
+
+**WebSocket over HTTP/2.** By default the external port speaks HTTP/1.1, and WebSocket traverses the mesh over HTTP/1.1 — which is exactly what `appProtocol: http` describes. Clients that could use [WebSocket over HTTP/2 (RFC 8441)](https://centrifugal.dev/docs/transports/websocket#websocket-over-http2-rfc-8441) fall back to HTTP/1.1 automatically, because a client may only attempt Extended CONNECT when the edge advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL`, which Istio does not do by default. An HTTP/2 ingress listener therefore keeps serving HTTP/2 for ordinary requests while WebSocket uses HTTP/1.1 — both coexist with no extra config.
+
+If you want true WebSocket-over-HTTP/2 end-to-end, it is opt-in on both sides: enable it on Centrifugo (TLS or `http_server.h2c_external`, plus the `GODEBUG=http2xconnect=1` runtime flag), set the external port's `appProtocol` to `http2`, and enable Extended CONNECT on the mesh — currently an `EnvoyFilter` setting `allow_connect`, as there is no Istio-native switch yet ([istio/istio#55680](https://github.com/istio/istio/discussions/55680)).
 
 ## Production Deployment
 
@@ -1358,9 +1373,18 @@ initContainers:
 |-----------|-------------|---------|
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | External service port | `8000` |
+| `service.appProtocol` | appProtocol for the external port (WebSocket/HTTP streaming/SSE) | `http` |
 | `serviceInternal.port` | Internal service port | `9000` |
+| `serviceInternal.appProtocol` | appProtocol for the internal port (HTTP API, metrics, health, admin) | `http` |
 | `serviceGrpc.port` | GRPC API service port | `10000` |
+| `serviceGrpc.appProtocol` | appProtocol for the GRPC API port | `grpc` |
 | `serviceUniGrpc.port` | Uni GRPC service port | `11000` |
+| `serviceUniGrpc.appProtocol` | appProtocol for the unidirectional GRPC port | `grpc` |
+
+Each service port advertises its L7 protocol via the standard Kubernetes [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field so a service mesh (Istio, Linkerd, …) routes it correctly out of the box — no manual protocol hints required. The external port defaults to `http` because Centrifugo serves it over HTTP/1.1 (WebSocket, HTTP streaming/SSE, emulation), and Istio's `http` protocol passes WebSocket upgrades and does not buffer streaming responses. `appProtocol` is ignored by plain kube-proxy, so non-mesh clusters are unaffected. Set an `appProtocol` to `""` to omit the field, or override it when a port runs differently:
+
+- `https` — if Centrifugo terminates TLS on the external port itself.
+- `http2` — if you enable Centrifugo's [WebSocket over HTTP/2 (RFC 8441)](https://centrifugal.dev/docs/transports/websocket#websocket-over-http2-rfc-8441). That transport also requires TLS or `http_server.h2c_external` on Centrifugo, and forwarding WebSocket-over-HTTP/2 through Istio needs Extended CONNECT enabled on the mesh (an `EnvoyFilter` setting `allow_connect`; there is no Istio-native switch yet — see [istio/istio#55680](https://github.com/istio/istio/discussions/55680)).
 
 ### Metrics Parameters
 

--- a/charts/centrifugo/tutorial.md
+++ b/charts/centrifugo/tutorial.md
@@ -956,7 +956,9 @@ Open <http://localhost:3000> (username: `admin`, password from above).
 
 ## Local Testing with Istio (Minikube)
 
-This walkthrough runs Centrifugo under [Istio](https://istio.io/) on a local Minikube cluster so you can confirm that WebSocket, HTTP streaming/SSE and the gRPC APIs work through a service mesh. It also shows *why* the chart sets an [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) on every Service port (see the [Service Mesh (Istio)](README.md#service-mesh-istio) section of the README). Every command below was run and verified against Istio 1.27.
+This walkthrough runs Centrifugo under [Istio](https://istio.io/) on a local Minikube cluster so you can confirm that WebSocket, HTTP streaming/SSE and the gRPC APIs work through a service mesh.
+It also shows *why* the chart sets an [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) on every Service port (see the [Service Mesh (Istio)](README.md#service-mesh-istio) section of the README).
+Every command below was run and verified against Istio 1.27.
 
 **Prerequisites:** a running Docker, plus `minikube`, `kubectl`, `helm`, and `istioctl`. Istio's [getting-started guide](https://istio.io/latest/docs/setup/getting-started/#download) covers installing `istioctl`; make sure it is on your `PATH`.
 
@@ -1163,7 +1165,9 @@ asyncio.run(main())
 #    reply: {"id":1,"connect":{"client":"...","version":"6.8.4 OSS",...}}
 ```
 
-This is the whole story in one place: the gateway serves **HTTP/2 for ordinary requests** while **WebSocket rides HTTP/1.1**, and both work with no special configuration. A browser that supports [WebSocket over HTTP/2 (RFC 8441)](https://centrifugal.dev/docs/transports/websocket#websocket-over-http2-rfc-8441) reaches the same outcome automatically — it only attempts Extended CONNECT when the edge advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL`, which Istio does not do by default, so it falls back to HTTP/1.1. (Enabling true WebSocket-over-HTTP/2 end-to-end is opt-in on both Centrifugo and Istio — see the README.)
+This is the whole story in one place: the gateway serves **HTTP/2 for ordinary requests** while **WebSocket rides HTTP/1.1**, and both work with no special configuration.
+A browser that supports [WebSocket over HTTP/2 (RFC 8441)](https://centrifugal.dev/docs/transports/websocket#websocket-over-http2-rfc-8441) reaches the same outcome automatically — it only attempts Extended CONNECT when the edge advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL`, which Istio does not do by default, so it falls back to HTTP/1.1.
+(Enabling true WebSocket-over-HTTP/2 end-to-end is opt-in on both Centrifugo and Istio — see the README.)
 
 Stop the port-forward when done:
 

--- a/charts/centrifugo/tutorial.md
+++ b/charts/centrifugo/tutorial.md
@@ -27,6 +27,12 @@ This tutorial provides step-by-step instructions for deploying Centrifugo v13 to
   - [8. Configure ALB Ingress](#8-configure-alb-ingress)
   - [9. Verify Installation](#9-verify-installation-eks)
   - [10. Monitoring Setup](#10-monitoring-setup-eks)
+- [Local Testing with Istio (Minikube)](#local-testing-with-istio-minikube)
+  - [1. Start Minikube and Install Istio](#1-start-minikube-and-install-istio)
+  - [2. Deploy Centrifugo into the Mesh](#2-deploy-centrifugo-into-the-mesh)
+  - [3. Verify Mesh Behavior](#3-verify-mesh-behavior)
+  - [4. Going Further: Ingress Gateway, TLS and HTTP/2](#4-going-further-ingress-gateway-tls-and-http2)
+  - [5. Cleanup](#5-cleanup)
 - [Production Considerations](#production-considerations)
 - [Troubleshooting](#troubleshooting)
 
@@ -325,10 +331,9 @@ spec:
   timeoutSec: 86400
   connectionDraining:
     drainingTimeoutSec: 30
-  # Enable HTTP/2 for better performance
-  http2:
-    enabled: true
 ```
+
+> Keep the load balancer talking to Centrifugo over HTTP/1.1 (the default). Don't switch the backend to HTTP/2 (e.g. via a `cloud.google.com/app-protocols: '{"external":"HTTP2"}'` annotation): Centrifugo serves the external port over HTTP/1.1 and WebSocket relies on the HTTP/1.1 `Upgrade` handshake, so an HTTP/2 backend would break client connections.
 
 Apply the BackendConfig:
 
@@ -429,8 +434,8 @@ curl http://localhost:9000/health
 Test via Ingress (after DNS propagates and certificate is active):
 
 ```bash
-# Test health endpoint (use internal service)
-kubectl port-forward svc/centrifugo-internal 9000:9000
+# Test health endpoint (internal port 9000 is exposed on the main service)
+kubectl port-forward svc/centrifugo 9000:9000
 curl http://localhost:9000/health
 
 # Test WebSocket connection via Ingress
@@ -946,6 +951,231 @@ kubectl port-forward svc/prometheus-grafana 3000:80
 ```
 
 Open <http://localhost:3000> (username: `admin`, password from above).
+
+---
+
+## Local Testing with Istio (Minikube)
+
+This walkthrough runs Centrifugo under [Istio](https://istio.io/) on a local Minikube cluster so you can confirm that WebSocket, HTTP streaming/SSE and the gRPC APIs work through a service mesh. It also shows *why* the chart sets an [`appProtocol`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) on every Service port (see the [Service Mesh (Istio)](README.md#service-mesh-istio) section of the README). Every command below was run and verified against Istio 1.27.
+
+**Prerequisites:** a running Docker, plus `minikube`, `kubectl`, `helm`, and `istioctl`. Istio's [getting-started guide](https://istio.io/latest/docs/setup/getting-started/#download) covers installing `istioctl`; make sure it is on your `PATH`.
+
+### 1. Start Minikube and Install Istio
+
+Istio needs a few spare cores and some memory, so give the cluster room:
+
+```bash
+minikube start --driver=docker --cpus=6 --memory=6500 --profile=centrifugo-istio
+
+# Install the Istio control plane and ingress gateway
+istioctl install --set profile=default -y
+```
+
+### 2. Deploy Centrifugo into the Mesh
+
+Create a namespace and enable automatic sidecar injection on it:
+
+```bash
+kubectl create namespace centrifugo
+kubectl label namespace centrifugo istio-injection=enabled
+```
+
+For this test we let clients connect without a JWT so we can exercise the transport directly. Create a values file:
+
+```yaml
+# istio-values.yaml
+config:
+  client:
+    insecure: true        # anonymous WebSocket connects (testing only!)
+  admin:
+    enabled: true
+    insecure: true
+```
+
+Install the chart and wait for the rollout:
+
+```bash
+helm install centrifugo centrifugal/centrifugo -n centrifugo -f istio-values.yaml
+kubectl -n centrifugo rollout status deploy/centrifugo
+```
+
+> **Do not use `client.insecure` in production.** It disables connection authentication and is only appropriate for a throwaway local test.
+
+### 3. Verify Mesh Behavior
+
+**a) The sidecar is injected.** On recent Istio the proxy runs as a native sidecar (an init container with `restartPolicy: Always`):
+
+```bash
+POD=$(kubectl -n centrifugo get pod -l app.kubernetes.io/name=centrifugo -o jsonpath='{.items[0].metadata.name}')
+kubectl -n centrifugo get pod "$POD" \
+  -o jsonpath='{range .spec.initContainers[*]}{.name}{"\n"}{end}'
+# -> istio-init
+#    istio-proxy
+```
+
+**b) The chart advertised `appProtocol` on each port:**
+
+```bash
+kubectl -n centrifugo get svc centrifugo \
+  -o jsonpath='{range .spec.ports[*]}{.name}{" -> appProtocol="}{.appProtocol}{"\n"}{end}'
+# -> external -> appProtocol=http
+#    internal -> appProtocol=http
+#    grpc     -> appProtocol=grpc
+#    uni-grpc -> appProtocol=grpc
+```
+
+**c) Istio classified the ports from those hints.** Because `appProtocol` is explicit, Istio programs each inbound port as HTTP deterministically — there is no protocol sniffing and no plain-TCP fallback. The inbound route configs confirm the external WebSocket port (8000) is treated as HTTP:
+
+```bash
+istioctl proxy-config routes "$POD" -n centrifugo | grep 'inbound|http'
+# -> inbound|http|8000 ...
+#    inbound|http|9000 ...
+#    inbound|http|10000 ...
+#    inbound|http|11000 ...
+```
+
+> Without `appProtocol`, Istio falls back to byte-level protocol sniffing and installs a plain-TCP fallback chain on the port. Detection is best-effort and can add connection latency for WebSocket — the intermittent behavior reported in [issue #23](https://github.com/centrifugal/helm-charts/issues/23). Declaring `appProtocol` removes the guesswork.
+
+**d) A WebSocket works end-to-end through the mesh.** Start a client pod in the same (injected) namespace, so traffic flows client-sidecar → mTLS → server-sidecar → Centrifugo:
+
+```bash
+kubectl -n centrifugo run wsclient --image=python:3.12-slim \
+  --restart=Never --command -- sleep 3600
+kubectl -n centrifugo wait --for=condition=Ready pod/wsclient --timeout=120s
+
+kubectl -n centrifugo exec wsclient -c wsclient -- pip install --quiet websockets
+
+kubectl -n centrifugo exec wsclient -c wsclient -- python -c '
+import asyncio, json, websockets
+async def main():
+    uri = "ws://centrifugo.centrifugo.svc.cluster.local:8000/connection/websocket"
+    async with websockets.connect(uri, subprotocols=["centrifuge-json"]) as ws:
+        print("handshake OK, subprotocol:", ws.subprotocol)
+        await ws.send(json.dumps({"connect": {}, "id": 1}))
+        print("reply:", await asyncio.wait_for(ws.recv(), timeout=5))
+asyncio.run(main())
+'
+# -> handshake OK, subprotocol: centrifuge-json
+#    reply: {"id":1,"connect":{"client":"...","version":"6.8.4 OSS","ping":25,"pong":true}}
+```
+
+A `connect` reply means the WebSocket upgrade traversed both Envoy sidecars and reached Centrifugo — no extra Istio configuration required.
+
+### 4. Going Further: Ingress Gateway, TLS and HTTP/2
+
+The steps above prove pod-to-pod (mesh-internal) traffic. To also exercise the edge — a TLS-terminating Istio ingress gateway — and see HTTP/2 coexisting with WebSocket, continue here.
+
+Create a self-signed certificate and expose it to the ingress gateway:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -days 2 \
+  -keyout key.pem -out cert.pem \
+  -subj "/CN=cent.local" -addext "subjectAltName=DNS:cent.local"
+
+kubectl -n istio-system create secret tls cent-tls --cert=cert.pem --key=key.pem
+```
+
+Define a `Gateway` (TLS on 443) and a `VirtualService` routing to the external port:
+
+```yaml
+# gateway.yaml
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: cent-gw
+  namespace: centrifugo
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        credentialName: cent-tls
+      hosts:
+        - cent.local
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: cent-vs
+  namespace: centrifugo
+spec:
+  hosts:
+    - cent.local
+  gateways:
+    - cent-gw
+  http:
+    - route:
+        - destination:
+            host: centrifugo.centrifugo.svc.cluster.local
+            port:
+              number: 8000
+```
+
+```bash
+kubectl apply -f gateway.yaml
+```
+
+Port-forward to the ingress gateway (a plain TCP forward, so TLS and ALPN negotiation pass through untouched):
+
+```bash
+kubectl -n istio-system port-forward svc/istio-ingressgateway 8443:443 &
+```
+
+**A normal request negotiates HTTP/2** through the gateway:
+
+```bash
+curl -sk --http2 --resolve cent.local:8443:127.0.0.1 \
+  https://cent.local:8443/connection/websocket \
+  -o /dev/null -w "negotiated: HTTP/%{http_version}  status=%{http_code}\n"
+# -> negotiated: HTTP/2  status=400
+```
+
+(The `400` is expected — it's a plain GET on the WebSocket path — but it proves the request reached Centrifugo over HTTP/2.)
+
+**A WebSocket through the same TLS gateway uses HTTP/1.1** and succeeds. Run it from the in-mesh client pod against the gateway (SNI `cent.local`):
+
+```bash
+IGIP=$(kubectl -n istio-system get svc istio-ingressgateway -o jsonpath='{.spec.clusterIP}')
+
+kubectl -n centrifugo exec wsclient -c wsclient -- python -c '
+import asyncio, json, ssl, websockets
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+ctx.set_alpn_protocols(["http/1.1"])   # RFC 6455 WebSocket uses HTTP/1.1
+async def main():
+    uri = "wss://cent.local:443/connection/websocket"
+    async with websockets.connect(uri, ssl=ctx, server_hostname="cent.local",
+                                  host="'"$IGIP"'", port=443,
+                                  subprotocols=["centrifuge-json"]) as ws:
+        alpn = ws.transport.get_extra_info("ssl_object").selected_alpn_protocol()
+        print("edge handshake OK, alpn:", alpn)
+        await ws.send(json.dumps({"connect": {}, "id": 1}))
+        print("reply:", await asyncio.wait_for(ws.recv(), timeout=5))
+asyncio.run(main())
+'
+# -> edge handshake OK, alpn: http/1.1
+#    reply: {"id":1,"connect":{"client":"...","version":"6.8.4 OSS",...}}
+```
+
+This is the whole story in one place: the gateway serves **HTTP/2 for ordinary requests** while **WebSocket rides HTTP/1.1**, and both work with no special configuration. A browser that supports [WebSocket over HTTP/2 (RFC 8441)](https://centrifugal.dev/docs/transports/websocket#websocket-over-http2-rfc-8441) reaches the same outcome automatically — it only attempts Extended CONNECT when the edge advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL`, which Istio does not do by default, so it falls back to HTTP/1.1. (Enabling true WebSocket-over-HTTP/2 end-to-end is opt-in on both Centrifugo and Istio — see the README.)
+
+Stop the port-forward when done:
+
+```bash
+kill %1   # the backgrounded port-forward
+```
+
+### 5. Cleanup
+
+```bash
+minikube delete --profile=centrifugo-istio
+```
 
 ---
 

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -160,8 +160,19 @@ service:
   annotations: {}
   # Provide any additional labels which may be required
   labels: {}
-  # Specify custom appProtocol for a service port.
-  appProtocol: ""
+  # appProtocol for this port. Advertises the L7 protocol so a service mesh
+  # (Istio, Linkerd, ...) routes it correctly without extra config. By default
+  # the external port speaks HTTP/1.1, serving WebSocket, HTTP streaming/SSE and
+  # emulation, so "http" is correct - Istio's http protocol passes WebSocket
+  # upgrades and does not buffer streaming responses.
+  # Change it only if you run the port differently:
+  #   - "https" if Centrifugo terminates TLS on this port itself.
+  #   - "http2" if you enable Centrifugo's WebSocket-over-HTTP/2 (RFC 8441). That
+  #     also needs TLS or http_server.h2c_external on Centrifugo, and passing WS
+  #     over HTTP/2 through Istio requires enabling Extended CONNECT on the mesh
+  #     (an EnvoyFilter with allow_connect - no Istio-native switch yet).
+  # Set to "" to omit the field entirely.
+  appProtocol: "http"
 
 # Internal service configuration.
 # By default, internal port is exposed on the main service above.
@@ -182,8 +193,10 @@ serviceInternal:
   # Specify clusterIP for the service. If not specified, Kubernetes will assign one.
   # Only used when useSeparate=true (separate service).
   clusterIP: ""
-  # Custom appProtocol for this port. Used in both modes.
-  appProtocol: ""
+  # appProtocol for this port. Advertises the L7 protocol to a service mesh.
+  # The internal port serves the HTTP server API, health checks, Prometheus
+  # metrics and admin UI - all HTTP - so "http" is correct. Set to "" to omit.
+  appProtocol: "http"
   # Service annotations. Only used when useSeparate=true (separate service).
   annotations: {}
   # Service labels. Only used when useSeparate=true (separate service).
@@ -208,8 +221,9 @@ serviceGrpc:
   # Specify clusterIP for the service. If not specified, Kubernetes will assign one.
   # Only used when useSeparate=true (separate service).
   clusterIP: ""
-  # Custom appProtocol for this port. Used in both modes.
-  appProtocol: ""
+  # appProtocol for this port. "grpc" lets a service mesh apply gRPC-aware
+  # routing to the server GRPC API. Set to "" to omit.
+  appProtocol: "grpc"
   # Service annotations. Only used when useSeparate=true (separate service).
   annotations: {}
   # Service labels. Only used when useSeparate=true (separate service).
@@ -234,8 +248,9 @@ serviceUniGrpc:
   # Specify clusterIP for the service. If not specified, Kubernetes will assign one.
   # Only used when useSeparate=true (separate service).
   clusterIP: ""
-  # Custom appProtocol for this port. Used in both modes.
-  appProtocol: ""
+  # appProtocol for this port. "grpc" lets a service mesh apply gRPC-aware
+  # routing to the unidirectional GRPC stream. Set to "" to omit.
+  appProtocol: "grpc"
   # Service annotations. Only used when useSeparate=true (separate service).
   annotations: {}
   # Service labels. Only used when useSeparate=true (separate service).


### PR DESCRIPTION
## Summary

Makes Centrifugo work with a service mesh (Istio, Linkerd, ...) out of the box by setting a sensible default `appProtocol` on every Service port. Closes the remaining item in #23.

Previously all service ports shipped with `appProtocol: ""`. Without an advertised L7 protocol, Istio falls back to protocol sniffing and, for the external port, installs a `tcp_proxy` fallback filter chain — the root cause of the mesh interop problems reported in #23. Setting `appProtocol` makes routing deterministic and L7-aware.

## Changes

- **`values.yaml`** — default `appProtocol` per port:
  - `service` (external, WS + HTTP streaming/SSE + emulation): `http`
  - `serviceInternal` (server API, health, metrics, admin): `http`
  - `serviceGrpc` (server GRPC API): `grpc`
  - `serviceUniGrpc` (unidirectional GRPC stream): `grpc`
  - Each documented inline, including when to override (`https`, `http2` for WebSocket-over-HTTP/2 / RFC 8441) and how to omit (`""`).
- **`README.md`** — new "Service Mesh (Istio)" section + `appProtocol` rows in the Service Parameters table.
- **`tutorial.md`** — new "Local Testing with Istio (Minikube)" walkthrough (verified live on Istio 1.27.1), plus two fixes to the existing GKE tutorial: removed the invalid `http2` field from BackendConfig (would break WebSocket) and corrected a `port-forward` reference to a service that only exists with `useSeparate=true`.
- **`Chart.yaml`** — version `13.3.2` → `13.4.0`.

## Compatibility

Non-breaking, so a minor bump. `appProtocol` takes precedence over the port-name convention, so no port rename was needed (renaming would have been redundant and breaking). Cloud ingress controllers that don't consume native `appProtocol` are unaffected: AWS Load Balancer Controller (uses `backend-protocol-version` annotation), GKE ingress-gce (uses `cloud.google.com/app-protocols` annotation), and L4 LBs / kube-proxy all ignore the field.

## Verification

Proven end-to-end on a live Istio 1.27.1 mesh (Minikube):
- Chart applies `appProtocol` correctly to all ports.
- External port 8000 inbound resolves to a deterministic `http_connection_manager` with **zero** `tcp_proxy` fallback chains (vs. sniffing + fallback when `appProtocol` is absent).
- WebSocket completes through the mesh (client sidecar → mTLS → server sidecar → Centrifugo).
- At a TLS ingress gateway, HTTP/2 for normal requests coexists with WebSocket over HTTP/1.1.
