### PR TITLE
Fix NOTES.txt internal service name when serviceInternal.useSeparate=true

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
 type: application
-version: 13.5.2
+version: 13.5.3
 appVersion: 6.9.3
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/NOTES.txt
+++ b/charts/centrifugo/templates/NOTES.txt
@@ -2,6 +2,10 @@ Centrifugo has been installed successfully!
 
 {{- $fullName := include "centrifugo.fullname" . }}
 {{- $namespace := .Release.Namespace }}
+{{- $internalSvcName := $fullName }}
+{{- if .Values.serviceInternal.useSeparate }}
+{{- $internalSvcName = printf "%s-internal" $fullName }}
+{{- end }}
 
 === ACCESSING CENTRIFUGO ===
 
@@ -56,7 +60,7 @@ External port (client connections):
 
 Internal port provides: API, Prometheus metrics, admin UI, health checks.
 
-  kubectl --namespace {{ $namespace }} port-forward svc/{{ $fullName }} {{ .Values.serviceInternal.port }}:{{ .Values.serviceInternal.port }}
+  kubectl --namespace {{ $namespace }} port-forward svc/{{ $internalSvcName }} {{ .Values.serviceInternal.port }}:{{ .Values.serviceInternal.port }}
 
   - Admin UI:    http://localhost:{{ .Values.serviceInternal.port }}/admin
   - Metrics:     http://localhost:{{ .Values.serviceInternal.port }}/metrics


### PR DESCRIPTION
## Summary
- `templates/NOTES.txt` always told users to `kubectl port-forward svc/<fullname> <internalPort>:<internalPort>` for the internal endpoints.
- When `serviceInternal.useSeparate: true`, the internal port is only exposed on the separate `<fullname>-internal` Service (see `service.yaml`'s `{{- if not .Values.serviceInternal.useSeparate }}` guard and `service-internal.yaml`) — it is removed from the main service. The printed command referenced a port that doesn't exist on the main service in that mode.
- Now NOTES.txt resolves the correct service name (`<fullname>` or `<fullname>-internal`) based on `serviceInternal.useSeparate`, matching the logic already used in the Ingress/HTTPRoute templates.

## Verification
- `helm lint charts/centrifugo` passes.
- `helm install test charts/centrifugo --dry-run` (default values): NOTES prints `svc/test-centrifugo`.
- `helm install test charts/centrifugo --dry-run --set serviceInternal.useSeparate=true`: NOTES now correctly prints `svc/test-centrifugo-internal`.