### PR TITLE
Fix stray null annotations key in host-check Job template

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
 type: application
-version: 13.5.3
+version: 13.5.4
 appVersion: 6.9.3
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/hooks/dns-check.yaml
+++ b/charts/centrifugo/templates/hooks/dns-check.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     {{- include "centrifugo.labels" . | nindent 4 }}
     tier: host-check
+  {{- with .Values.hostCheck.annotations }}
   annotations:
-    {{- if .Values.hostCheck.annotations }}
-    {{- toYaml .Values.hostCheck.annotations | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:


### PR DESCRIPTION
## Summary
- `templates/hooks/dns-check.yaml` always emitted the `annotations:` key on the host-check Job, even when `hostCheck.annotations` was left at its default empty map — rendering as `annotations:` with a null value.
- Every other template in the chart uses the `{{- with .Values.x.annotations }}` pattern to omit the key entirely when unset. This template used `{{- if }}` on the key's *contents* while the `annotations:` line itself was unconditional, so it was the one manifest that diverged from that convention.
- This matters in particular here because `values.yaml` documents setting `hostCheck.annotations` to `helm.sh/hook: pre-install,pre-upgrade` to make this Job behave as a Helm hook — the default (hook disabled) manifest should render cleanly without a dangling null field.

## Verification
- `helm lint charts/centrifugo` — passes.
- `helm template` with `hostCheck.enabled=true` and no `hostCheck.annotations` set: `annotations:` key is now omitted entirely (previously rendered as `annotations:` with no value).
- `helm template` with `hostCheck.annotations` set (e.g. `helm.sh/hook: pre-install`): renders correctly, unchanged from before.
- `helm template` across a wide combination of feature flags (serviceMonitor, useSeparate services, ingress/ingressInternal, autoscaling, podDisruptionBudget, hostCheck) renders successfully with no regressions.
- No test suite exists in this repo beyond `ct lint`/`helm lint`; `ct` itself isn't installed locally, so `helm lint` plus manual `helm template` renders were used as the closest available verification.