### PR TITLE
Apply nodePort for LoadBalancer service type, not just NodePort

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
 type: application
-version: 13.5.4
+version: 13.5.5
 appVersion: 6.9.3
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/service-grpc-api.yaml
+++ b/charts/centrifugo/templates/service-grpc-api.yaml
@@ -26,7 +26,7 @@ spec:
       appProtocol: {{ .Values.serviceGrpc.appProtocol }}
       {{- end }}
       name: grpc
-      {{- if (and (eq .Values.serviceGrpc.type "NodePort") (not (empty .Values.serviceGrpc.nodePort))) }}
+      {{- if (and (or (eq .Values.serviceGrpc.type "NodePort") (eq .Values.serviceGrpc.type "LoadBalancer")) (not (empty .Values.serviceGrpc.nodePort))) }}
       nodePort: {{ .Values.serviceGrpc.nodePort }}
       {{- end }}
   selector:

--- a/charts/centrifugo/templates/service-internal.yaml
+++ b/charts/centrifugo/templates/service-internal.yaml
@@ -26,7 +26,7 @@ spec:
       appProtocol: {{ .Values.serviceInternal.appProtocol }}
       {{- end }}
       name: internal
-      {{- if (and (eq .Values.serviceInternal.type "NodePort") (not (empty .Values.serviceInternal.nodePort))) }}
+      {{- if (and (or (eq .Values.serviceInternal.type "NodePort") (eq .Values.serviceInternal.type "LoadBalancer")) (not (empty .Values.serviceInternal.nodePort))) }}
       nodePort: {{ .Values.serviceInternal.nodePort }}
       {{- end }}
   selector:

--- a/charts/centrifugo/templates/service-uni-grpc.yaml
+++ b/charts/centrifugo/templates/service-uni-grpc.yaml
@@ -26,7 +26,7 @@ spec:
       appProtocol: {{ .Values.serviceUniGrpc.appProtocol }}
       {{- end }}
       name: uni-grpc
-      {{- if (and (eq .Values.serviceUniGrpc.type "NodePort") (not (empty .Values.serviceUniGrpc.nodePort))) }}
+      {{- if (and (or (eq .Values.serviceUniGrpc.type "NodePort") (eq .Values.serviceUniGrpc.type "LoadBalancer")) (not (empty .Values.serviceUniGrpc.nodePort))) }}
       nodePort: {{ .Values.serviceUniGrpc.nodePort }}
       {{- end }}
   selector:

--- a/charts/centrifugo/templates/service.yaml
+++ b/charts/centrifugo/templates/service.yaml
@@ -25,7 +25,7 @@ spec:
       {{- if .Values.service.appProtocol }}
       appProtocol: {{ .Values.service.appProtocol }}
       {{- end }}
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
 {{- if not .Values.serviceInternal.useSeparate }}
@@ -36,7 +36,7 @@ spec:
       {{- if .Values.serviceInternal.appProtocol }}
       appProtocol: {{ .Values.serviceInternal.appProtocol }}
       {{- end }}
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.serviceInternal.nodePort))) }}
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.serviceInternal.nodePort))) }}
       nodePort: {{ .Values.serviceInternal.nodePort }}
       {{- end }}
 {{- end }}
@@ -48,7 +48,7 @@ spec:
       {{- if .Values.serviceGrpc.appProtocol }}
       appProtocol: {{ .Values.serviceGrpc.appProtocol }}
       {{- end }}
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.serviceGrpc.nodePort))) }}
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.serviceGrpc.nodePort))) }}
       nodePort: {{ .Values.serviceGrpc.nodePort }}
       {{- end }}
 {{- end }}
@@ -60,7 +60,7 @@ spec:
       {{- if .Values.serviceUniGrpc.appProtocol }}
       appProtocol: {{ .Values.serviceUniGrpc.appProtocol }}
       {{- end }}
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.serviceUniGrpc.nodePort))) }}
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.serviceUniGrpc.nodePort))) }}
       nodePort: {{ .Values.serviceUniGrpc.nodePort }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
## What changed

All four service templates (`service.yaml`, `service-internal.yaml`, `service-grpc-api.yaml`, `service-uni-grpc.yaml`) gated the `nodePort` field to only render when the service `type` was exactly `NodePort`. Kubernetes also allows explicitly requesting a `nodePort` on `LoadBalancer`-type services, and `values.yaml` already documents this (e.g. `service.nodePort`: "Specify the nodePort value for the LoadBalancer and NodePort service types."), but the templates never honored it for `LoadBalancer`.

## Why

A user setting `service.type: LoadBalancer` together with `service.nodePort`, `serviceInternal.nodePort`, `serviceGrpc.nodePort`, or `serviceUniGrpc.nodePort` (either on the shared service or a dedicated one via `useSeparate: true`) would have that value silently dropped, contradicting the documented behavior in `values.yaml`.

## How verified

This chart has no unit-test harness (CI relies on `ct lint` / `ct install` against a kind cluster). I ran locally:

- `helm lint charts/centrifugo` — passes.
- `helm template` with `service.type=NodePort` — nodePort still renders (no regression).
- `helm template` with `service.type=ClusterIP` — nodePort still correctly omitted.
- `helm template` with `service.type=LoadBalancer` plus `nodePort` set on the shared service and on all three optional ports (internal/grpc/uni-grpc) — all four now render `nodePort` as expected, which failed before this change.
- `helm template` with `useSeparate: true` and `type: LoadBalancer` on each of the three dedicated services — `nodePort` renders correctly on each.
- Default `helm template` render (no overrides) — unaffected.

I did not add a values-based CI fixture, since this repo doesn't have a unit-test framework for the chart (`ct install` in CI covers install-time validation, not this kind of field-rendering assertion) — the `helm template` checks above are the closest equivalent to a regression test and are recorded here for reviewers to reproduce.