### PR TITLE
Fix NOTES.txt namespace when namespaceOverride is set

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
 type: application
-version: 13.5.6
+version: 13.5.7
 appVersion: 6.9.4
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/NOTES.txt
+++ b/charts/centrifugo/templates/NOTES.txt
@@ -1,7 +1,7 @@
 Centrifugo has been installed successfully!
 
 {{- $fullName := include "centrifugo.fullname" . }}
-{{- $namespace := .Release.Namespace }}
+{{- $namespace := include "centrifugo.namespace" . }}
 {{- $internalSvcName := $fullName }}
 {{- if .Values.serviceInternal.useSeparate }}
 {{- $internalSvcName = printf "%s-internal" $fullName }}


### PR DESCRIPTION
## What

`NOTES.txt` derived its `$namespace` variable from `.Release.Namespace` directly, while every other template in the chart renders resources into `{{ include "centrifugo.namespace" . }}`, which honours `namespaceOverride`.

## Why

With `namespaceOverride` set, all resources land in the overridden namespace but every command printed after install pointed at the release namespace — the external and internal `port-forward` commands, the NodePort/LoadBalancer service lookups, and the `get pods` / `logs` verification commands. All of them failed or silently found nothing.

`NOTES.txt` was the last remaining raw `.Release.Namespace` usage in the chart (`grep -rn "Release.Namespace" charts/` now only matches the helper's own definition). The same class of fix was already applied to the PodDisruptionBudget template, noted in the README v13 changelog as "PodDisruptionBudget now uses namespace helper (supports `namespaceOverride`)".

Chart version bumped 13.5.6 → 13.5.7.

## How it was verified

`helm lint` passes (default values, and with `namespaceOverride` + `ingress.enabled` + hosts). `helm template` renders cleanly with default values and with all three `useSeparate` service splits enabled.

The bug was reproduced with a render-based check rather than a permanent test, since the chart has no test harness beyond `ct lint`/`helm lint` and NOTES output is not part of the rendered manifests that `ct` validates.

Before the fix — `helm install rel charts/centrifugo --namespace relns --set namespaceOverride=other-ns --dry-run`:

- rendered manifests: `namespace: other-ns`
- NOTES: `kubectl --namespace relns port-forward svc/rel-centrifugo 8000:8000` (and the same wrong namespace on the internal port-forward, `get pods` and `logs` lines)

After the fix, the same command prints `--namespace other-ns` throughout. Re-checked the `NodePort` and `LoadBalancer` NOTES branches (plus `serviceInternal.useSeparate=true`) under the override — all now report `other-ns`. Without `namespaceOverride`, output is byte-identical to before: still `relns`.