### PR TITLE
Fix PodDisruptionBudget rendering with maxUnavailable and zero values

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
 type: application
-version: 13.5.7
+version: 13.5.8
 appVersion: 6.9.4
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/README.md
+++ b/charts/centrifugo/README.md
@@ -1337,8 +1337,8 @@ initContainers:
 | `affinity` | Affinity rules for pod assignment | `{}` |
 | `topologySpreadConstraints` | Topology spread constraints | `[]` |
 | `podDisruptionBudget.enabled` | Enable PodDisruptionBudget | `false` |
-| `podDisruptionBudget.minAvailable` | Minimum available pods | `nil` |
-| `podDisruptionBudget.maxUnavailable` | Maximum unavailable pods | `nil` |
+| `podDisruptionBudget.minAvailable` | Minimum available pods (ignored when `maxUnavailable` is set) | `1` |
+| `podDisruptionBudget.maxUnavailable` | Maximum unavailable pods (takes precedence over `minAvailable`) | `nil` |
 
 ### Pod-Level Parameters
 

--- a/charts/centrifugo/templates/poddisruptionbudget.yaml
+++ b/charts/centrifugo/templates/poddisruptionbudget.yaml
@@ -1,4 +1,9 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- $minAvailable := .Values.podDisruptionBudget.minAvailable }}
+{{- $maxUnavailable := .Values.podDisruptionBudget.maxUnavailable }}
+{{- /* Treat null/empty as unset, but keep 0 which is a valid budget value. */}}
+{{- $hasMinAvailable := not (or (kindIs "invalid" $minAvailable) (eq (toString $minAvailable) "")) }}
+{{- $hasMaxUnavailable := not (or (kindIs "invalid" $maxUnavailable) (eq (toString $maxUnavailable) "")) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -10,10 +15,10 @@ spec:
   selector:
     matchLabels:
       {{- include "centrifugo.selectorLabels" . | nindent 6 }}
-  {{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-  {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- /* Kubernetes rejects a PDB with both fields set, so maxUnavailable wins over the minAvailable default. */}}
+  {{- if $hasMaxUnavailable }}
+  maxUnavailable: {{ $maxUnavailable }}
+  {{- else if $hasMinAvailable }}
+  minAvailable: {{ $minAvailable }}
   {{- end }}
 {{- end }}

--- a/charts/centrifugo/values.yaml
+++ b/charts/centrifugo/values.yaml
@@ -599,10 +599,10 @@ topologySpreadConstraints: []
 podDisruptionBudget:
   enabled: false
   # Minimum number/percentage of pods that must remain available during disruption.
-  # Cannot be used together with maxUnavailable.
+  # Ignored when maxUnavailable is set.
   minAvailable: 1
   # Maximum number/percentage of pods that can be unavailable during disruption.
-  # Cannot be used together with minAvailable.
+  # When set (including 0), it is used instead of minAvailable.
   # maxUnavailable: 1
 
 # ============================================


### PR DESCRIPTION
## What changed

`templates/poddisruptionbudget.yaml` now renders **one** budget field:

- `maxUnavailable` if it is set (including `0`),
- otherwise `minAvailable` (including `0`).

`null` or an empty string still counts as unset. I also updated the values.yaml comments and the README parameter table to describe this. The table listed `minAvailable` with a default of `nil`, but the real default is `1`. The chart version is bumped to 13.5.8.

## Why

There were two bugs in the old template:

1. **`maxUnavailable` could not be used as documented.** The README says `minAvailable: 2  # or use maxUnavailable: 1`. But `values.yaml` defaults `minAvailable: 1`, so setting only `maxUnavailable: 1` rendered both fields:
   ```yaml
   minAvailable: 1
   maxUnavailable: 1
   ```
   The API server rejects this because the two fields are mutually exclusive, so the install or upgrade fails. The only way around it was to also set `minAvailable` to `null`, `""` or `0`.
2. **Zero was silently dropped.** The `{{- if .Values.podDisruptionBudget.maxUnavailable }}` checks treat `0` as false. So `maxUnavailable: 0` (block voluntary evictions) was ignored: you either kept the default `minAvailable: 1` or got no budget field at all.

## Compatibility

Every combination that rendered a valid PDB before renders the same output now, with one exception: `maxUnavailable: 0` set on top of the default `minAvailable: 1`. It used to be ignored silently. Now it renders `maxUnavailable: 0` as written, which **blocks voluntary evictions, including node drains**. Anyone who has that value in their values file will see stricter behavior after upgrading.

Workarounds keep working unchanged: `minAvailable: null`/`""`/`0` together with `maxUnavailable: N` still renders `maxUnavailable: N`.

`minAvailable: 0` on its own used to render no budget field and now renders `minAvailable: 0`, which is what was asked for.

I considered failing at render time when both fields are set, instead of letting `maxUnavailable` win. I didn't do that because it would break the `minAvailable: 0` + `maxUnavailable: N` workaround, which renders fine today, and would force extra config for the documented `maxUnavailable: 1` usage.

## How I verified

The repo has no template test suite (CI runs `ct lint` and `ct install`). To validate the fix, I rendered the PDB with `helm template -s templates/poddisruptionbudget.yaml` using the old template (from `HEAD`) and the new one, across these value combinations:

| values | before | after |
|---|---|---|
| defaults | `minAvailable: 1` | `minAvailable: 1` |
| `maxUnavailable=1` | `minAvailable: 1` + `maxUnavailable: 1` (invalid) | `maxUnavailable: 1` |
| `minAvailable=null, maxUnavailable=1` | `maxUnavailable: 1` | `maxUnavailable: 1` |
| `minAvailable=null, maxUnavailable=0` | *(no budget field)* | `maxUnavailable: 0` |
| `maxUnavailable=0` (default min) | `minAvailable: 1` | `maxUnavailable: 0` |
| `minAvailable=0` | *(no budget field)* | `minAvailable: 0` |
| `minAvailable=3` | `minAvailable: 3` | `minAvailable: 3` |
| `minAvailable="", maxUnavailable=1` | `maxUnavailable: 1` | `maxUnavailable: 1` |
| values file: `minAvailable: null`, `maxUnavailable: "25%"` | `maxUnavailable: 25%` | `maxUnavailable: 25%` |
| values file: `minAvailable: "50%"` | `minAvailable: 50%` | `minAvailable: 50%` |
| values file: `minAvailable: 0`, `maxUnavailable: 1` | `maxUnavailable: 1` | `maxUnavailable: 1` |
| values file: `minAvailable: 2`, `maxUnavailable: 1` | both fields (invalid) | `maxUnavailable: 1` |

The comparison covered both `--set` (int64) and values-file (float64) zeros. With `podDisruptionBudget.enabled=false`, no PDB is rendered. `helm lint` passes with default values and with `podDisruptionBudget.enabled=true --set podDisruptionBudget.maxUnavailable=1`.

This check is not in the diff. The repo has no template-rendering test harness to put it in. Adding a `ci/*-values.yaml` file would change what `ct install` exercises in CI: once a `ci/` directory exists, `ct` installs only with those values files instead of the defaults. That is a bigger change than this fix warrants.