### PR TITLE
Render revisionHistoryLimit when set to 0

### DIFF
--- a/charts/centrifugo/Chart.yaml
+++ b/charts/centrifugo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centrifugo
 description: Centrifugo is a scalable real-time messaging server in language-agnostic way
 type: application
-version: 13.5.8
+version: 13.5.9
 appVersion: 6.9.4
 home: https://centrifugal.dev
 icon: https://centrifugal.dev/img/favicon.png

--- a/charts/centrifugo/templates/deployment.yaml
+++ b/charts/centrifugo/templates/deployment.yaml
@@ -14,8 +14,9 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
-  {{- with .Values.revisionHistoryLimit }}
-  revisionHistoryLimit: {{ . }}
+  {{- /* Treat null/empty as unset, but keep 0 which means no old ReplicaSets are retained. */}}
+  {{- if not (or (kindIs "invalid" .Values.revisionHistoryLimit) (eq (toString .Values.revisionHistoryLimit) "")) }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
## What changed

`templates/deployment.yaml` wrapped `revisionHistoryLimit` in `{{- with }}`. Go templates treat `0` as falsy, so `revisionHistoryLimit: 0` removed the field completely. Kubernetes then used its default of 10 old ReplicaSets instead of keeping none.

The template now renders the field whenever it is set, including `0`. Only `null` or an empty value counts as unset. This is the same check `poddisruptionbudget.yaml` uses for zero values since #166. The chart version is bumped from 13.5.8 to 13.5.9.

## Why

`revisionHistoryLimit: 0` is a valid setting. It's commonly used with GitOps tools, where rollback history lives in Git and old ReplicaSets just pile up. The chart documents the value as "Number of old ReplicaSets to retain", but a value of 0 was silently ignored.

## How I verified it

I rendered with `helm template`, once from master's chart and once from this branch:

| values | master | this branch |
|---|---|---|
| `revisionHistoryLimit=0` | *(field missing)* | `revisionHistoryLimit: 0` |
| `revisionHistoryLimit=3` | `3` | `3` |
| default | `10` | `10` |
| `revisionHistoryLimit=null` | *(field missing)* | *(field missing)* |
| `revisionHistoryLimit=""` | *(field missing)* | *(field missing)* |

The first row reproduces the bug on master and shows the fix; the other rows are unchanged. I also diffed the full default render between master and this branch, ignoring the `helm.sh/chart` label. The only difference is the `checksum/config` pod annotation, which is expected: the ConfigMap has the chart-version label, so its hash changes with the version bump. `helm lint --strict` passes. A render with autoscaling, PDB, ServiceMonitor, ingress and a separate internal service all enabled also succeeds.

The regression check was a one-off render comparison and is not part of this PR. The repo has no template unit-test setup (no helm-unittest suite or `ci/` values files), and adding one would mean changing CI, which is out of scope for a one-line fix.
